### PR TITLE
[improvement] don't include 'plugins' folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "setupTestFrameworkScriptFile": "<rootDir>/src/setupJest.ts",
     "transformIgnorePatterns": [
       "node_modules/(?!@ngrx|@ionic-native|@ionic)"
-    ]
+    ],
+    "testRegex": "src.*?\\.(test|spec)\\.(ts|js)$"
   }
 }


### PR DESCRIPTION
preset for angular didn't consider "plugins" folder that is used when platform is added to ionic project. Files with tests from plugins were included and tests were failing. Better regex for Ionic 2+ projects added.