### PR TITLE
Locate tests only under src folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ $ npm install jest jest-preset-angular @types/jest --save-dev
 {
   "jest": {
     "preset": "jest-preset-angular",
+    "roots": [
+      "src"
+    ],
+    "testRegex": "\\.spec\\.ts$",
     "setupTestFrameworkScriptFile": "<rootDir>/src/setupJest.ts",
     "transformIgnorePatterns": [
       "node_modules/(?!@ngrx|@ionic-native|@ionic)"

--- a/package.json
+++ b/package.json
@@ -46,6 +46,10 @@
   },
   "jest": {
     "preset": "jest-preset-angular",
+    "roots": [
+      "src"
+    ],
+    "testRegex": "\\.spec\\.ts$",
     "setupTestFrameworkScriptFile": "<rootDir>/src/setupJest.ts",
     "transformIgnorePatterns": [
       "node_modules/(?!@ngrx|@ionic-native|@ionic)"


### PR DESCRIPTION
Use the [roots](https://facebook.github.io/jest/docs/en/configuration.html#roots-array-string) config option alongside `testRegex` to restrict the folders which Jest use to locate test files and source files.

**Fixes**: #6 