### PR TITLE
Add missing setup info to exclude `node_modules` from tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,9 @@ Object.defineProperty(window, 'getComputedStyle', {
   },
   "include": [
     "**/*.spec.ts"
+  ],
+  "exclude": [
+    "node_modules"
   ]
 }
 ```


### PR DESCRIPTION
Thanks to @oliverhm for alerting about this.

Closes #17 