### PR TITLE
Travis: Add Node.js versions 8 & 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ cache: yarn
 
 node_js:
   - "6"
+  - "8"
+  - "10"
 
 script:
   - yarn test -- --verbose --coverage --coverageReporters=lcov


### PR DESCRIPTION
Set Node.js versions 8 and 10 in the `travis.yml` file for early detection of problems with those versions.

Seems the latest Node.js v10 is not working with `@ionic/app-scripts` v3.1.9, see #20